### PR TITLE
Don't use ez_setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 """\
 """
-from ez_setup import use_setuptools
-use_setuptools()
-
 import os
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
There doesn't seem to be a reason to use `ez_setup`, and not all python installations will have it anyway.
