### PR TITLE
Fix importing validation for python3

### DIFF
--- a/bitcoinaddress/__init__.py
+++ b/bitcoinaddress/__init__.py
@@ -1,1 +1,1 @@
-from validation import validate
+from .validation import validate


### PR DESCRIPTION
Note that there are all sorts of fun python3 errors in the tests anyway, but at least this imports now.
